### PR TITLE
Verify Main Website begins with protocol

### DIFF
--- a/force-app/main/default/objects/Card__c/fields/Main_Website__c.field-meta.xml
+++ b/force-app/main/default/objects/Card__c/fields/Main_Website__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Main_Website__c</fullName>
     <externalId>false</externalId>
-    <label>Main Website</label>
+    <label>Main Website URL</label>
     <required>false</required>
     <trackTrending>false</trackTrending>
     <type>Url</type>

--- a/force-app/main/default/objects/Card__c/validationRules/Validate_htttp_or_https_URL.validationRule-meta.xml
+++ b/force-app/main/default/objects/Card__c/validationRules/Validate_htttp_or_https_URL.validationRule-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Validate_htttp_or_https_URL</fullName>
+    <active>true</active>
+    <description
+  >Validates that a URL begins with either http:// or https://</description>
+    <errorConditionFormula
+  >NOT(OR(BEGINS(Main_Website__c, &quot;http://&quot;),BEGINS(Main_Website__c, &quot;https://&quot;)))</errorConditionFormula>
+    <errorDisplayField>Main_Website__c</errorDisplayField>
+    <errorMessage>Please start URL with http:// or https://</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
This adds a validation check to the Main_Website__c field in Card__c. It requires the value for that field to begin with either `http://` or `https://`.

Also it changes the display name of the field to "Main Website URL" to make it clear that protocol is expected.

Closes #41 