### PR TITLE
Implement "Import Stickers" button

### DIFF
--- a/force-app/main/default/classes/StickerController.cls
+++ b/force-app/main/default/classes/StickerController.cls
@@ -1,5 +1,5 @@
 public with sharing class StickerController {
-  @AuraEnabled(cacheable=true)
+  @AuraEnabled
   public static List<Sticker__c> getStickers() {
     return [
       SELECT Id, Name, Image__c, Image_Alt_Text__c

--- a/force-app/main/default/classes/StickerController.cls
+++ b/force-app/main/default/classes/StickerController.cls
@@ -1,4 +1,7 @@
 public with sharing class StickerController {
+  public class CSVImportException extends Exception {
+  }
+
   @AuraEnabled
   public static List<Sticker__c> getStickers() {
     return [
@@ -49,5 +52,59 @@ public with sharing class StickerController {
       );
       insert sticker;
     }
+  }
+
+  @AuraEnabled
+  public static void importStickers() {
+    // Note: %5E is the ^ character. Salesforce doesn't allow it unencoded in a path
+    String stickersCsvUrl = 'https://unpkg.com/wicked-coolkit@%5E1.0.1/dist/stickers/stickers.csv';
+
+    HttpRequest req = new HttpRequest();
+    req.setEndpoint(stickersCsvUrl);
+    req.setMethod('GET');
+
+    System.Debug(req.getEndpoint());
+
+    Http http = new Http();
+    HTTPResponse res = http.send(req);
+
+    // Handle 302 redirects
+    while (res.getStatusCode() == 302) {
+      String newUrl = res.getHeader('Location');
+
+      // Handle Location response header without protocol and host
+      if (newUrl.startsWith('/')) {
+        newUrl = 'https://' + (new URL(req.getEndpoint())).getHost() + newUrl;
+      }
+
+      req.setEndpoint(newUrl);
+      res = new Http().send(req);
+    }
+
+    String csvResponseBody = res.getBody();
+
+    try {
+      List<Sticker__c> stickerList = new List<Sticker__c>();
+      String[] csvLines = csvResponseBody.split('\n');
+
+      // NOTE: does not work if field value contains comma
+      for (Integer i = 1; i < csvLines.size(); i++) {
+        Sticker__c stickerObj = new Sticker__c();
+        String[] csvRecordData = csvLines[i].split(',');
+        stickerObj.Image_Alt_Text__c = dequote(csvRecordData[0]);
+        stickerObj.Name = dequote(csvRecordData[1]);
+        stickerList.add(stickerObj);
+      }
+
+      if (stickerList.size() > 0) {
+        insert stickerList;
+      }
+    } catch (Exception e) {
+      throw new CSVImportException(e.getMessage(), e);
+    }
+  }
+
+  private static String dequote(String str) {
+    return str.removeStart('"').removeEnd('"');
   }
 }

--- a/force-app/main/default/lwc/stickersForm/stickersForm.html
+++ b/force-app/main/default/lwc/stickersForm/stickersForm.html
@@ -1,43 +1,58 @@
 <template>
   <div class="container-outer">
-    <lightning-card>
-      <h3 slot="title" class="title">
-        <span>Stickers</span>
-        <div class="slds-badge">{selectedStickers}/{maxStickers}</div>
-      </h3>
-      <div class="stickers-grid">
-        <div
-          class="sticker-cell"
-          for:each={stickers}
-          for:item="sticker"
-          key={sticker.id}
-        >
-          <template if:true={sticker.disabled}>
-            <input
-              id={sticker.id}
-              name="stickers[]"
-              type="checkbox"
-              value={sticker.id}
-              checked={sticker.selected}
-              onchange={onChangeSticker}
-              disabled
-            />
-          </template>
-          <template if:false={sticker.disabled}>
-            <input
-              id={sticker.id}
-              name="stickers[]"
-              type="checkbox"
-              value={sticker.id}
-              checked={sticker.selected}
-              onchange={onChangeSticker}
-            />
-          </template>
-          <label for={sticker.id}>
-            <img src={sticker.imgSrc} alt={sticker.imgAlt} />
-          </label>
+    <template if:false={stickersAvailable}>
+      <lightning-card title="Stickers">
+        <lightning-button
+          variant="brand"
+          label="Import Sticker Data"
+          title="Click to import sticker data"
+          icon-name="action:add_file"
+          onclick={handleImportStickersClick}
+          class="slds-m-left_x-small"
+          disabled={importButtonDisabled}
+        ></lightning-button>
+      </lightning-card>
+    </template>
+    <template if:true={stickersAvailable}>
+      <lightning-card>
+        <h3 slot="title" class="title">
+          <span>Stickers</span>
+          <div class="slds-badge">{selectedStickers}/{maxStickers}</div>
+        </h3>
+        <div class="stickers-grid">
+          <div
+            class="sticker-cell"
+            for:each={stickers}
+            for:item="sticker"
+            key={sticker.id}
+          >
+            <template if:true={sticker.disabled}>
+              <input
+                id={sticker.id}
+                name="stickers[]"
+                type="checkbox"
+                value={sticker.id}
+                checked={sticker.selected}
+                onchange={onChangeSticker}
+                disabled
+              />
+            </template>
+            <template if:false={sticker.disabled}>
+              <input
+                id={sticker.id}
+                name="stickers[]"
+                type="checkbox"
+                value={sticker.id}
+                checked={sticker.selected}
+                onchange={onChangeSticker}
+              />
+            </template>
+            <label for={sticker.id}>
+              <img src={sticker.imgSrc} alt={sticker.imgAlt} />
+            </label>
+          </div>
         </div>
-      </div>
-    </lightning-card>
+      </lightning-card>
+    </template>
   </div>
 </template>

--- a/force-app/main/default/lwc/stickersForm/stickersForm.js
+++ b/force-app/main/default/lwc/stickersForm/stickersForm.js
@@ -5,10 +5,13 @@ import addSticker from "@salesforce/apex/StickerController.addSticker";
 import deleteSticker from "@salesforce/apex/StickerController.deleteSticker";
 import getStickers from "@salesforce/apex/StickerController.getStickers";
 import getStickersByCard from "@salesforce/apex/StickerController.getStickersByCard";
+import importStickers from "@salesforce/apex/StickerController.importStickers";
 
 import { host } from "c/tradingCard";
 
 export default class StickersForm extends LightningElement {
+  importButtonDisabled;
+
   @api
   recordId;
 
@@ -26,6 +29,10 @@ export default class StickersForm extends LightningElement {
 
   get selectedStickers() {
     return this.getSelectedStickers().length;
+  }
+
+  get stickersAvailable() {
+    return this.stickers.length && this.stickers.length > 0;
   }
 
   loadStickers() {
@@ -121,5 +128,20 @@ export default class StickersForm extends LightningElement {
         s.disabled = false;
       });
     }
+  }
+
+  handleImportStickersClick() {
+    this.importButtonDisabled = true;
+
+    importStickers()
+      .then(() => {
+        this.connectedCallback();
+      })
+      .catch((error) => {
+        console.error(error);
+      })
+      .finally(() => {
+        this.importButtonDisabled = false;
+      });
   }
 }

--- a/force-app/main/default/remoteSiteSettings/unpkg.remoteSite-meta.xml
+++ b/force-app/main/default/remoteSiteSettings/unpkg.remoteSite-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<RemoteSiteSetting xmlns="http://soap.sforce.com/2006/04/metadata">
+    <disableProtocolSecurity>false</disableProtocolSecurity>
+    <isActive>true</isActive>
+    <url>https://unpkg.com</url>
+</RemoteSiteSetting>


### PR DESCRIPTION
This adds an "Import Sticker Data" button to the Trading Card UI so that the user doesn't have to use the Data Import Wizard in Setup.

When the user clicks "Import Sticker Data" the CSV is fetched from https://unpkg.com/wicked-coolkit@^1.0.1/dist/stickers/stickers.csv and its records are imported into Salesforce.

https://user-images.githubusercontent.com/275734/106987583-cb82a400-673b-11eb-97de-b7773618ccff.mp4

