### PR TITLE
Allow blank Main Website

### DIFF
--- a/force-app/main/default/objects/Card__c/validationRules/Validate_htttp_or_https_URL.validationRule-meta.xml
+++ b/force-app/main/default/objects/Card__c/validationRules/Validate_htttp_or_https_URL.validationRule-meta.xml
@@ -3,9 +3,9 @@
     <fullName>Validate_htttp_or_https_URL</fullName>
     <active>true</active>
     <description
-  >Validates that a URL begins with either http:// or https://</description>
+  >Validates that a field begins with either http:// or https:// (blank allowed too)</description>
     <errorConditionFormula
-  >NOT(OR(BEGINS(Main_Website__c, &quot;http://&quot;),BEGINS(Main_Website__c, &quot;https://&quot;)))</errorConditionFormula>
+  >NOT(OR(BEGINS(Main_Website__c, &quot;http://&quot;),BEGINS(Main_Website__c, &quot;https://&quot;),ISBLANK(Main_Website__c)))</errorConditionFormula>
     <errorDisplayField>Main_Website__c</errorDisplayField>
     <errorMessage>Please start URL with http:// or https://</errorMessage>
 </ValidationRule>


### PR DESCRIPTION
When I added the validation for `http://` or `https://` as required at the beginning of the `Main Website` field, it no longer allowed that field to be blank. We want to allow users to not have to provide a Main Website. This PR allows the field to be blank.